### PR TITLE
Fix Edip.Utils.do_cmd error case

### DIFF
--- a/lib/edip/runner.ex
+++ b/lib/edip/runner.ex
@@ -39,7 +39,7 @@ defmodule Edip.Runner do
 
   defp clone_edip do
     info "Download EDIP ..."
-    do_cmd("git clone #{@clone_options} #{@edip_repo} #{@edip_dir}", &ignore/1)
+    do_cmd("git clone #{@clone_options} #{@edip_repo} #{@edip_dir}", &ignore/1, "Downloading EDIP")
   end
 
   defp recreate_app_dir do
@@ -66,7 +66,7 @@ defmodule Edip.Runner do
   defp package_release(opts) do
     info "Packaging ..."
     silent = silent?(opts)
-    do_cmd("make -C #{work_dir} #{package_make_vars(opts)}", silent_build?(silent))
+    do_cmd("make -C #{work_dir} #{package_make_vars(opts)}", silent_build?(silent), "Packaging release")
   end
 
   defp silent_build?(true), do: &silent_log/1

--- a/lib/edip/utils.ex
+++ b/lib/edip/utils.ex
@@ -16,15 +16,17 @@ defmodule Edip.Utils do
   @doc "Exits with exit status 1"
   def abort!, do: exit({:shutdown, 1})
 
-  # Ignore a message when used as the callback for Mix.Shell.cmd
+  @doc "Ignore a message when used as the callback for Mix.Shell.cmd"
   def ignore(_), do: nil
 
   # do_cmd("command", &ignore/1)
   # do_cmd("command", &IO.write/1)
-  def do_cmd(command, callback) do
+  def do_cmd(command, callback, step) do
     case cmd(command, callback) do
       0 -> :ok
-      _ -> {:error, "Release step failed. Please fix any errors and try again."}
+      _ ->
+        error("#{step} stage failed. Please fix any errors and try again.")
+        abort!
     end
   end
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,0 +1,18 @@
+defmodule Edip.UtilsTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+  import Edip.Utils
+
+  test "do_cmd" do
+    assert ExUnit.CaptureIO.capture_io(fn ->
+      do_cmd("echo EDIP", &IO.puts/1, "Echoing")
+    end) == "EDIP\n\n"
+  end
+
+  test "do_cmd failing" do
+    fun = fn ->
+      assert catch_exit(do_cmd("fail_echo EDIP", &IO.puts/1, "Echoing")) == {:shutdown, 1}
+    end
+    assert capture_io(fun) =~ "Echoing stage failed. Please fix any errors and try again"
+  end
+end


### PR DESCRIPTION
This is how it looks if it fails:

<img width="574" alt="1__bash 2" src="https://cloud.githubusercontent.com/assets/30873/9149143/1efab5ae-3def-11e5-97c9-94ec966af10a.png">

<img width="503" alt="1__bash" src="https://cloud.githubusercontent.com/assets/30873/9149147/2f9c42a6-3def-11e5-83a2-afec5e13c1ac.png">

Instead of creating a new function I simply used `do_cmd` to abort in case of error. I'm passing a string as a "step" so we can output which stage failed. Any advise for a better approach?
