### PR TITLE
Add custom volume mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,13 @@ Adn don't forget to add `exrm` to your project:
     mix edip --silent
     mix edip -s
 
+    # Map additional volumes for use while building the release
+    mix edip --mapping <FROM>:<TO>[:<OPTION>]
+    mix edip -m <FROM>:<TO>[:<OPTION>]
+
+To pull dependencies stored in private github repositories you will need to make your SSH keys accessible from the container doing the build:
+
+mix edip --mapping /path/to/home/.ssh:/root/ssh.
+
 If `--name` and `--prefix` are given, the name option takes precedence (prefix will be ignored).
 <!-- endmoduledoc: Mix.Tasks.Edip -->

--- a/lib/edip/options.ex
+++ b/lib/edip/options.ex
@@ -4,33 +4,68 @@ defmodule Edip.Options.Package do
             prefix: nil
 end
 
+defmodule Edip.Options.Mapping do
+  defstruct from: nil,
+            to:   nil,
+            options: nil
+end
+
 defmodule Edip.Options do
   alias Edip.Options.Package
+  alias Edip.Options.Mapping
 
-  @option_aliases [n: :name, t: :tag, p: :prefix, s: :silent]
-  @option_stricts [name: :string, tag: :string, prefix: :string, silent: :boolean]
+  @option_aliases [n: :name, t: :tag, p: :prefix, s: :silent, m: :mapping]
+  @option_stricts [
+    name:    :string,
+    tag:     :string,
+    prefix:  :string,
+    silent:  :boolean,
+    mapping: [:string, :keep]
+  ]
 
-  defstruct silent:  false,
-            writer:  &Edip.Utils.PrefixWriter.write/1,
-            package: %Package{}
+  defstruct silent:   false,
+            writer:   &Edip.Utils.PrefixWriter.write/1,
+            package:  %Package{},
+            mappings: []
 
   def from_args(args) do
     valid_options = parse_args(args)
 
     writer  = writer(valid_options)
     package = struct(Package, valid_options)
-    struct(__MODULE__, Dict.merge(valid_options, [writer: writer, package: package]))
+    mappings = valid_options[:mappings]
+    struct(__MODULE__, Dict.merge(valid_options, [writer: writer, package: package, mappings: mappings]))
   end
 
   defp parse_args(args) do
-    {valid_opts, _, _} = OptionParser.parse(args, aliases: @option_aliases, strict: @option_stricts)
-    valid_opts
+    {parsed_opts, _, _} = OptionParser.parse(args, aliases: @option_aliases, strict: @option_stricts)
+    |> consolidate_mappings
+
+    parsed_opts
   end
 
   defp writer(valid_options) do
     case Dict.get(valid_options, :silent) do
       true -> &Edip.Utils.LogWriter.write/1
       _    -> &Edip.Utils.PrefixWriter.write/1
+    end
+  end
+
+  defp consolidate_mappings({parsed, argv, errors}) do
+    mappings = parsed
+    |> Keyword.get_values(:mapping)
+    |> Enum.map(&create_valid_mapping/1)
+
+    parsed = parsed |> Keyword.delete(:mapping) |> Keyword.merge(mappings: mappings)
+
+    {parsed, argv, errors}
+  end
+
+  defp create_valid_mapping(mapping_opt) do
+    case mapping_opt |> String.split(":") do
+      [from, to] -> %Mapping{from: from, to: to}
+      [from, to, options] -> %Mapping{from: from, to: to, options: options}
+      _ -> raise "Volume mapping is /from/vol:/to/vol or /from/vol/:/to/vol:access_option"
     end
   end
 end

--- a/lib/edip/runner.ex
+++ b/lib/edip/runner.ex
@@ -4,7 +4,7 @@ defmodule Edip.Runner do
   alias Edip.ImageConfig
   alias Edip.Settings
 
-  @edip_version          "0.3.0"
+  @edip_version          "0.4.2"
   @edip_tool             "asaaki/edip-tool:#{@edip_version}"
   @docker_cmd            "docker"
   @docker_run            "#{@docker_cmd} run --rm"
@@ -81,7 +81,7 @@ defmodule Edip.Runner do
   defp step_build_artifact({:error, _, _} = error), do: error
   defp step_build_artifact({_result, _msg, options}) do
     info("Creating artifact (might take a while) ...")
-    command = "#{@docker_run} #{volumes} #{release_settings(options)} #{@edip_tool}"
+    command = "#{@docker_run} #{volumes(options)} #{release_settings(options)} #{@edip_tool}"
 
     options.writer.("$> #{command}\n")
     case do_cmd(command, options.writer) do
@@ -162,8 +162,9 @@ defmodule Edip.Runner do
   defp tarball_dir,     do: current_dir <> "/" <> @tarball_dir_name
   defp artifact_config, do: tarball_dir <> "/" <> @artifact_config
 
-  defp volumes do
+  defp volumes(options) do
     [
+      Settings.from_mapping_options(options.mappings),
       "-v #{current_dir}:#{@container_source_dir}",
       "-v #{tarball_dir}:#{@container_tarball_dir}"
     ]

--- a/lib/edip/settings.ex
+++ b/lib/edip/settings.ex
@@ -1,8 +1,17 @@
 defmodule Edip.Settings do
+  alias Edip.Options.Mapping
   def from_package_options(options) do
     parse_package_options(options)
     |> Enum.map_join(" ", &(~s(-e "#{&1}")))
   end
+
+  def from_mapping_options(options) do
+    options |>
+    Enum.map_join(" ", &(~s(-v "#{mapping_to_string(&1)}")))
+  end
+
+  defp mapping_to_string(m = %Mapping{options: nil}), do: "#{m.from}:#{m.to}"
+  defp mapping_to_string(m = %Mapping{}), do: "#{m.from}:#{m.to}:#{m.options}"
 
   defp parse_package_options(options) do
     {_, vars} =

--- a/test/edip/options_test.exs
+++ b/test/edip/options_test.exs
@@ -1,0 +1,100 @@
+defmodule OptionsTest do
+  use ExUnit.Case
+
+  alias Edip.Options
+
+  test "degenerate options string (defaults)" do
+    parsed = Options.from_args([])
+
+    assert parsed == %Options{}
+    assert parsed.package == %Options.Package{}
+    assert parsed.writer == &Edip.Utils.PrefixWriter.write/1
+    assert parsed.mappings == []
+  end
+
+  test "package -- name option" do
+    parsed = Options.from_args(["--name", "foo"])
+
+    %Options{package: pkg_options} = parsed
+    assert pkg_options.name == "foo"
+
+    # Test same option in alias form
+    parsed = Options.from_args(["-n", "pfoo"])
+
+    %Options{package: pkg_options} = parsed
+    assert pkg_options.name == "pfoo"
+  end
+
+  test "package -- tag option" do
+    parsed = Options.from_args(["--tag", "tagged"])
+
+    %Options{package: pkg_options} = parsed
+    assert pkg_options.tag == "tagged"
+
+    # Test same option in alias form
+    parsed = Options.from_args(["-t", "taggeddy"])
+
+    %Options{package: pkg_options} = parsed
+    assert pkg_options.tag == "taggeddy"
+  end
+
+  test "package -- prefix option" do
+    parsed = Options.from_args(["--prefix", "prefoo"])
+
+    %Options{package: pkg_options} = parsed
+    assert pkg_options.prefix == "prefoo"
+
+    # Test same option in alias form
+    parsed = Options.from_args(["-p", "pfoo"])
+
+    %Options{package: pkg_options} = parsed
+    assert pkg_options.prefix == "pfoo"
+  end
+
+  test "writer -- silent option" do
+    parsed = Options.from_args(["--silent", true])
+
+    %Options{writer: writer} = parsed
+    assert writer == &Edip.Utils.LogWriter.write/1
+
+    # Test same option in alias form
+    parsed = Options.from_args(["-s"])
+
+    %Options{writer: writer} = parsed
+    assert writer == &Edip.Utils.LogWriter.write/1
+  end
+
+  test "mappings -- basic mapping" do
+    parsed = Options.from_args(["--mapping", "/from/a/vol:/to/a/vol"])
+
+    %Options{mappings: mappings} = parsed
+    assert length(mappings) == 1
+
+    [mapping|[]] = mappings
+    assert mapping == %Options.Mapping{from: "/from/a/vol", to: "/to/a/vol"}
+  end
+
+  test "mappings -- mapping with options" do
+    parsed = Options.from_args(["--mapping", "/from/a/vol:/to/a/vol:ro"])
+
+    %Options{mappings: mappings} = parsed
+    assert length(mappings) == 1
+
+    [mapping|[]] = mappings
+    assert mapping == %Options.Mapping{from: "/from/a/vol", to: "/to/a/vol", options: "ro"}
+  end
+
+  test "mappings -- multiple mappings" do
+    %Options{mappings: mappings} = [
+      "--mapping", "/from/a/vol:/to/a/vol",
+      "--mapping", "/from/another/vol:/to/another/vol"
+    ]
+    |> Options.from_args
+
+    assert length(mappings) == 2
+
+    [mapping1|[mapping2]] = mappings
+    assert mapping1 == %Options.Mapping{from: "/from/a/vol", to: "/to/a/vol"}
+    assert mapping2 == %Options.Mapping{from: "/from/another/vol", to: "/to/another/vol"}
+  end
+end

--- a/test/edip/settings_test.exs
+++ b/test/edip/settings_test.exs
@@ -1,0 +1,55 @@
+defmodule SettingsTest do
+  use ExUnit.Case
+
+  alias Edip.Options
+
+  test "package name is converted to environment var spec string" do
+    pkg_options =
+      %Options.Package{name: "pkg_name"}
+      |> Edip.Settings.from_package_options
+
+   assert String.contains?(pkg_options, "RELEASE_NAME=pkg_name")
+  end
+
+  test "tag name is converted to environment var spec string" do
+    pkg_options =
+      %Options.Package{tag: "taggar"}
+    |> Edip.Settings.from_package_options
+
+    assert String.contains?(pkg_options, "RELEASE_TAG=taggar")
+  end
+
+  test "package prefix is converted to environment var spec string" do
+    pkg_options =
+      %Options.Package{prefix: "prefixer"}
+    |> Edip.Settings.from_package_options
+
+    assert String.contains?(pkg_options, "RELEASE_PREFIX=prefixer")
+  end
+
+  test "basic mapping is formatted for docker run command" do
+    mapping_options =
+      [%Options.Mapping{from: "/from/vol", to: "/to/vol"}]
+    |> Edip.Settings.from_mapping_options
+
+    assert mapping_options == ~s(-v "/from/vol:/to/vol")
+  end
+
+  test "mapping with access option is formatted for docker run command" do
+    mapping_options =
+      [%Options.Mapping{from: "/from/vol", to: "/to/vol", options: "ro"}]
+    |> Edip.Settings.from_mapping_options
+
+    assert mapping_options == ~s(-v "/from/vol:/to/vol:ro")
+  end
+
+  test "multiple mappings are formatted for docker run command" do
+    mapping_options =
+      [%Options.Mapping{from: "/from/vol", to: "/to/vol"},
+       %Options.Mapping{from: "/from/diff/vol", to: "/to/diff/vol", options: "rw"}]
+    |> Edip.Settings.from_mapping_options
+
+    assert String.contains?(mapping_options, ~s(-v "/from/vol:/to/vol"))
+    assert String.contains?(mapping_options, ~s(-v "/from/diff/vol:/to/diff/vol:rw"))
+  end
+end


### PR DESCRIPTION
Here are the changes to the mix-edip extension used by the EDIP docker image changes submitted in https://github.com/asaaki/docker-images/pull/1. 

As I've updated the documentation on how to use the new option, I _think_ the code can stand by itself with no further explanation. That said, if you have questions or changes, please let me know! Thanks!
